### PR TITLE
return NSNull when failed to init NSString from NSData

### DIFF
--- a/MPMessagePack/MPMessagePackReader.m
+++ b/MPMessagePack/MPMessagePackReader.m
@@ -67,7 +67,16 @@
       }
       NSMutableData *data = [NSMutableData dataWithLength:length];
       context->read(context, [data mutableBytes], length);
-      return [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+        
+      NSString *dataString = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+        
+      if (!dataString) {
+          return [NSNull null];
+      }
+      else
+      {
+          return dataString;
+      }
     }
 
     case CMP_TYPE_FIXARRAY:


### PR DESCRIPTION
Because of an encoding error on my API server, some string value can not be converted from NSData correctly. The value return nil, so that the result will be nil in the end. I think an encoding error of one value should not affect other values, as the repo msgpack-java. :) 
