### PR TITLE
Detach input/output stream delegates in dealloc

### DIFF
--- a/MPMessagePack/MPMessagePackClient.m
+++ b/MPMessagePack/MPMessagePackClient.m
@@ -51,6 +51,11 @@ NSString *const MPErrorInfoKey = @"MPErrorInfoKey";
   return self;
 }
 
+- (void)dealloc {
+    _inputStream.delegate = nil;
+    _outputStream.delegate = nil;
+}
+
 - (void)setInputStream:(NSInputStream *)inputStream outputStream:(NSOutputStream *)outputStream {
   _inputStream = inputStream;
   _outputStream = outputStream;


### PR DESCRIPTION
The `delegate` properties for both `NSInputStream` and `NSOutputStream` are marked as `assign` rather than `weak`.

For safety, it's always recommended to detach delegate methods in the `dealloc` method.