### PR TITLE
Remove `platform` attributes in lieu of `deployment_target`

### DIFF
--- a/MPMessagePack.podspec
+++ b/MPMessagePack.podspec
@@ -11,11 +11,9 @@ Pod::Spec.new do |s|
 
   s.dependency "GHODictionary"
 
-  s.platform = :ios, "6.0"
   s.ios.deployment_target = "6.0"
   s.ios.source_files = "MPMessagePack/**/*.{c,h,m}", "RPC/**/*.{c,h,m}"
 
-  s.platform = :osx, "10.8"
   s.osx.deployment_target = "10.8"
   s.osx.source_files = "MPMessagePack/**/*.{c,h,m}", "RPC/**/*.{c,h,m}", "XPC/**/*.{c,h,m}"
 


### PR DESCRIPTION
Fixes problem that causes pod install to error out with:

The platform of the target `...` (iOS 9.0) is not compatible with `MPMessagePack (1.3.8)`, which does not support `ios`.

I think that `platform` is only intended to be used to specify a pod support a single platform. In previous versions of MPMessagePack the `platform` attribute was set on the `ios` and `osx` targets, where it had no actual effect (the `deployment_target` values were used).

This is worthy of close review. I've only tested with ios targets.

Reference:

https://guides.cocoapods.org/syntax/podspec.html#platform