### PR TITLE
correctly propagate error up the encoding chain

### DIFF
--- a/MPMessagePack/MPMessagePackWriter.m
+++ b/MPMessagePack/MPMessagePackWriter.m
@@ -52,7 +52,11 @@ static size_t mp_writer(cmp_ctx_t *ctx, const void *data, size_t count) {
 
 + (NSMutableData *)writeObject:(id)obj options:(MPMessagePackWriterOptions)options error:(NSError **)error {
   MPMessagePackWriter *messagePack = [[MPMessagePackWriter alloc] init];
-  [messagePack writeObject:obj options:options error:error];
+  
+  if(![messagePack writeObject:obj options:options error:error]) {
+    return nil;
+  }
+  
   return messagePack.data;
 }
 

--- a/MPMessagePack/MPMessagePackWriter.m
+++ b/MPMessagePack/MPMessagePackWriter.m
@@ -53,7 +53,7 @@ static size_t mp_writer(cmp_ctx_t *ctx, const void *data, size_t count) {
 + (NSMutableData *)writeObject:(id)obj options:(MPMessagePackWriterOptions)options error:(NSError **)error {
   MPMessagePackWriter *messagePack = [[MPMessagePackWriter alloc] init];
   
-  if(![messagePack writeObject:obj options:options error:error]) {
+  if (![messagePack writeObject:obj options:options error:error]) {
     return nil;
   }
   

--- a/RPC/MPRPCProtocol.m
+++ b/RPC/MPRPCProtocol.m
@@ -27,12 +27,22 @@ NSString *const MPErrorInfoKey = @"MPErrorInfoKey";
 - (NSData *)encodeRequestWithMethod:(NSString *)method params:(NSArray *)params messageId:(NSInteger)messageId options:(MPMessagePackWriterOptions)options framed:(BOOL)framed error:(NSError **)error {
   NSArray *request = @[@(0), @(messageId), method, params ? params : NSNull.null];
   NSData *data = [MPMessagePackWriter writeObject:request options:options error:error];
+
+  if(!data) {
+    return nil;
+  }
+  
   return framed ? [self _frameData:data] : data;
 }
 
 - (NSData *)encodeResponseWithResult:(id)result error:(id)error messageId:(NSInteger)messageId options:(MPMessagePackWriterOptions)options framed:(BOOL)framed encodeError:(NSError **)encodeError {
   NSArray *response = @[@(1), @(messageId), error ? error : NSNull.null, result ? result : NSNull.null];
   NSData *data = [MPMessagePackWriter writeObject:response options:options error:encodeError];
+  
+  if(!data) {
+    return nil;
+  }
+  
   return framed ? [self _frameData:data] : data;
 }
 


### PR DESCRIPTION
When using RPC calls, we noticed we would get errors when decodings but no error messages when encoding.  After some debugging, we noticed some error checking was not present in the writer code.  What we found was the `writeObject` class of functions would drill down an object, encounter a unhandled type, and return NO.  Unfortunately, the `NO` would go up the chain, but along with it would be a non-`nil` `data` object.  

This is by no means an exhaustive fix, but it was enough for us to fix the bad behavior.  Opening the request to illustrate the issue.  There might be some other functions not conforming to the error handling paradigm.
