### PR TITLE
Fix build error when using Carthage

### DIFF
--- a/MPMessagePack.xcodeproj/project.pbxproj
+++ b/MPMessagePack.xcodeproj/project.pbxproj
@@ -44,6 +44,8 @@
 		009D441D1BCEF7560030DD7E /* MPDispatchRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 009D441B1BCEF7560030DD7E /* MPDispatchRequest.m */; };
 		009D44201BCEFE270030DD7E /* MPRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 009D441E1BCEFE270030DD7E /* MPRequest.h */; };
 		009D44211BCEFE270030DD7E /* MPRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 009D441F1BCEFE270030DD7E /* MPRequest.m */; };
+		0DEC9FD01DF78A9B00680313 /* GHODictionary.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0DEC9FCF1DF78A9B00680313 /* GHODictionary.framework */; };
+		0DEC9FD21DF78AA400680313 /* GHODictionary.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0DEC9FD11DF78AA400680313 /* GHODictionary.framework */; };
 		33220B1F1CFF954B00F3C3DA /* MPMessagePack.h in Headers */ = {isa = PBXBuildFile; fileRef = 006555AF19662E3000288AE7 /* MPMessagePack.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		33220B201CFF954B00F3C3DA /* cmp.c in Sources */ = {isa = PBXBuildFile; fileRef = 00FB32E119661B0A0060AF33 /* cmp.c */; };
 		33220B211CFF954B00F3C3DA /* cmp.h in Headers */ = {isa = PBXBuildFile; fileRef = 00FB32E219661B0A0060AF33 /* cmp.h */; };
@@ -68,8 +70,6 @@
 		33220B341CFF954F00F3C3DA /* MPRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 009D441F1BCEFE270030DD7E /* MPRequest.m */; };
 		33220B351CFF954F00F3C3DA /* MPDispatchRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 009D441A1BCEF7560030DD7E /* MPDispatchRequest.h */; };
 		33220B361CFF954F00F3C3DA /* MPDispatchRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 009D441B1BCEF7560030DD7E /* MPDispatchRequest.m */; };
-		33220B5A1CFF987F00F3C3DA /* GHODictionary.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 33220B591CFF987F00F3C3DA /* GHODictionary.framework */; };
-		33220B5C1CFF988500F3C3DA /* GHODictionary.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 33220B5B1CFF988500F3C3DA /* GHODictionary.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -124,10 +124,10 @@
 		00FB32E119661B0A0060AF33 /* cmp.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cmp.c; sourceTree = "<group>"; };
 		00FB32E219661B0A0060AF33 /* cmp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cmp.h; sourceTree = "<group>"; };
 		00FB32E51966240B0060AF33 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		0DEC9FCF1DF78A9B00680313 /* GHODictionary.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GHODictionary.framework; path = Carthage/Build/iOS/GHODictionary.framework; sourceTree = "<group>"; };
+		0DEC9FD11DF78AA400680313 /* GHODictionary.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GHODictionary.framework; path = Carthage/Build/Mac/GHODictionary.framework; sourceTree = "<group>"; };
 		33220B171CFF952F00F3C3DA /* MPMessagePack.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MPMessagePack.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		33220B1B1CFF952F00F3C3DA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		33220B591CFF987F00F3C3DA /* GHODictionary.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GHODictionary.framework; path = ../GHODictionary/build/Debug/GHODictionary.framework; sourceTree = "<group>"; };
-		33220B5B1CFF988500F3C3DA /* GHODictionary.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GHODictionary.framework; path = "../GHODictionary/build/Debug-iphoneos/GHODictionary.framework"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -135,7 +135,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				33220B5A1CFF987F00F3C3DA /* GHODictionary.framework in Frameworks */,
+				0DEC9FD21DF78AA400680313 /* GHODictionary.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -151,7 +151,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				33220B5C1CFF988500F3C3DA /* GHODictionary.framework in Frameworks */,
+				0DEC9FD01DF78A9B00680313 /* GHODictionary.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -267,8 +267,8 @@
 		D0B28C1420694B0CAA57DAF6 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				33220B5B1CFF988500F3C3DA /* GHODictionary.framework */,
-				33220B591CFF987F00F3C3DA /* GHODictionary.framework */,
+				0DEC9FD11DF78AA400680313 /* GHODictionary.framework */,
+				0DEC9FCF1DF78A9B00680313 /* GHODictionary.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -711,6 +711,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
 				GCC_NO_COMMON_BLOCKS = YES;
 				INFOPLIST_FILE = "MPMessagePack iOS/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -738,6 +742,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
 				GCC_NO_COMMON_BLOCKS = YES;
 				INFOPLIST_FILE = "MPMessagePack iOS/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";


### PR DESCRIPTION
Problem: Currently attempting to use MPMessagePack as a dependency using Carthage no longer works. Currently, carthage support is broken.
Trying to run `carthage update` with your Cartfile specifying `github "gabriel/MPMessagePack"` will give you an error while compiling: `fatal error: 'GHODictionary/GHODictionary.h' file not found`

This is not unexpected, as the current master branch of  `MPMessagePack` will also give you the same compile error when building the iOS target using Xcode 8.1

Fix: Modify the MPMessagePack.xcodeproj file so that it references the GHODictionary frameworks built in the `Carthage/Build/` folder. 

Validating the fix: Per [carthage instructions](https://github.com/Carthage/Carthage#archive-prebuilt-frameworks-into-one-zip-file) you can test if the framework is carthage compatible by going into the project folder and running `carthage build --no-skip-current`.  This command attempts to build your framework's targets and if it succeeds, it usually means your users will also be able to use your framework using carthage. Before the fix, the command fails. After the fix, it succeeds.

Pitfalls: How does this impact Cocoapods users? Are they able to build with this new setup?  We can also consider including GHODictionary as a submodule as [recommended by the community ](https://www.quora.com/How-should-an-OSS-library-be-structured-for-distribution-with-both-Carthage-and-CocoaPods/answer/Justin-Spahr-Summers?srid=TWZu) and that would allow us to support any dependency manager easily because our own dependencies would be built by Xcode itself using submodules. I have a proof of concept branch doing just that.  Let me know how to proceed


