### PR TITLE
Fix warning when -Wimplicit-retain-self is on

### DIFF
--- a/RPC/MPMessagePackClient.m
+++ b/RPC/MPMessagePackClient.m
@@ -260,7 +260,7 @@ typedef void (^MPDispatchSignal)(NSInteger messageId);
       [self _handleMessage:message];
     }
 
-    _readBuffer = [[_readBuffer subdataWithRange:NSMakeRange(reader.index, _readBuffer.length - reader.index)] mutableCopy]; // TODO: Fix mutable copy (this might actually no-op tho)
+    self->_readBuffer = [[self->_readBuffer subdataWithRange:NSMakeRange(reader.index, self->_readBuffer.length - reader.index)] mutableCopy]; // TODO: Fix mutable copy (this might actually no-op tho)
     [self checkReadBuffer];
   }];
 }


### PR DESCRIPTION
* Adds explicit `self`s to ivars accessed within a block